### PR TITLE
Return module to pool on regex.Close()

### DIFF
--- a/regex.go
+++ b/regex.go
@@ -364,6 +364,12 @@ func (pr *privateRegex) Close() (err error) {
 	if pr == nil || pr.mod == nil {
 		return nil
 	}
+    defer func() {
+		modulePool.Put(pr.mod)
+		pr.mod = nil
+		runtime.SetFinalizer(pr, nil)
+	}()
+
 	err = pr.closeRegexPtrs()
 	if nErr := pr.closeMatchPtr(); err == nil {
 		err = nErr
@@ -378,11 +384,6 @@ func (pr *privateRegex) Close() (err error) {
 		if nErr := pr.free(ctx, uint32(pr.matchStrBuffer)); err == nil {
 			err = nErr
 		}
-	}
-	if pr.mod != nil {
-		modulePool.Put(pr.mod)
-		pr.mod = nil
-		runtime.SetFinalizer(pr, nil)
 	}
 	return err
 }


### PR DESCRIPTION
`privateRegex.Close()`'s error handling was circumventing returning the module back to the pool. I don't understand the code well enough to know whether the other error handling logic is correct, but even in the error case I imagine we want to return the module objects to the pool.