### PR TITLE
bug fix: copy error when closing a runtime

### DIFF
--- a/pool.go
+++ b/pool.go
@@ -178,7 +178,7 @@ func (pool *Pool) closeRuntime(ctx context.Context, rtrackerIdx int, rtracker *R
 	// We then remove the runtime from the slice
 	newSlice := make([]*RuntimeTracker, len(pool.runtimes)-1)
 	copy(newSlice, pool.runtimes[:rtrackerIdx])
-	copy(newSlice, pool.runtimes[rtrackerIdx+1:])
+	copy(newSlice[rtrackerIdx:], pool.runtimes[rtrackerIdx+1:])
 	pool.runtimes = newSlice
 }
 


### PR DESCRIPTION
When closing a runtime, the code to copy the other runtimes into a new slice was accidentally copying two sets of runtimes both to the start of the new slice, resulting in the slice containing `nil` elements at the end and having some runtimes overwritten. This ended up triggering a panic once we started closing all leaked regexes. 

I'll look into ideas for testing tomorrow, but I did kick off [a quick sanity test in this auto-bump PR](https://github.com/dolthub/doltgresql/pull/1330), where we originally saw the panic that showed us this issue. 